### PR TITLE
feat: cachix 401 and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,20 @@
 ## Cachix
 
 A private [Cachix](https://cachix.org) binary cache (`grady-saccullo.cachix.org`) is used to
-avoid redundant builds across machines. When you run `nix run .#switch`, the Nix daemon checks
-this cache (along with the public `nix-community` and `numtide` caches) for pre-built derivations
-before building from source. After a successful switch, the build output is pushed back to the
-cache so other machines can pull it.
+avoid redundant builds across machines. When you run `nix run .#switch`, Nix checks this cache
+(along with the public `nix-community` and `numtide` caches) for pre-built derivations before
+building from source. After a successful switch, the build output is pushed back to the cache
+so other machines can pull it.
 
-Because the cache is private, the Nix daemon needs credentials to fetch from it. Nix supports
+This cache is configured in `flake.nix`'s `nixConfig`, scoped to this flake — **not** in the
+machine-wide `nix.settings` (`modules/shared/nix.nix`, which keeps only the public caches). As
+a global substituter it leaked into every unrelated `devenv` project, whose cache probe hits
+this private cache unauthenticated and emits `HTTP error 401` warnings. Flake-scoping confines
+it to operations on this flake.
+
+Because the cache is private, Nix needs credentials to fetch from it. Nix supports
 this through a [netrc](https://everything.curl.dev/usingcurl/netrc) file — the same format
-`curl` uses for HTTP authentication. The daemon reads this file and attaches the credentials
+`curl` uses for HTTP authentication. Nix reads this file and attaches the credentials
 when making requests to the cache.
 
 ### Setup
@@ -28,15 +34,21 @@ Create the netrc file with your Cachix auth token (found on the
 [Cachix dashboard](https://app.cachix.org)):
 
 ```bash
-sudo sh -c 'cat > /etc/nix/netrc << EOF
+sudo sh -c 'umask 022; cat > /etc/nix/netrc << EOF
 machine grady-saccullo.cachix.org password <CACHIX_AUTH_TOKEN>
 EOF'
-sudo chmod 600 /etc/nix/netrc
+sudo chmod 0644 /etc/nix/netrc
 ```
 
-This tells the Nix daemon: when connecting to `grady-saccullo.cachix.org`, authenticate with
-the given token. The file lives at `/etc/nix/netrc` so it works on both macOS and Linux without
-any path differences.
+This tells Nix: when connecting to `grady-saccullo.cachix.org`, authenticate with the given
+token. The file lives at `/etc/nix/netrc` so it works on both macOS and Linux without any
+path differences.
+
+The mode is `0644` (not `0600`) on purpose: during `nix run .#switch`, Nix queries this cache
+both as root (the `nix-darwin` daemon) and as your user (flake evaluation / substituter
+probing). If the file is only root-readable, the user-side queries can't authenticate and the
+private cache returns `HTTP 401` warnings. A read-only token for a personal cache at `0644` on
+a single-user machine is a negligible exposure — do not "harden" this back to `0600`.
 
 ## Project Structure
 

--- a/configurations/personal-darwin.nix
+++ b/configurations/personal-darwin.nix
@@ -65,7 +65,7 @@ in {
     };
     podman.enable = true;
     raycast.enable = true;
-    # soundsource.enable = true;
+    soundsource.enable = true;
     fzf.searchPaths = [
       "$HOME/Desktop/"
       "$HOME/Documents/"
@@ -74,6 +74,7 @@ in {
       "$HOME/personal/"
     ];
     spotify.enable = true;
+    steam.enable = true;
     tailscale.enable = true;
     utm.enable = true;
     wezterm.enable = true;

--- a/flake.lock
+++ b/flake.lock
@@ -28,16 +28,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1774235677,
-        "narHash": "sha256-0ryNYmzDAeRlrzPTAgmzGH/Cgc8iv/LBN6jWGUANvIk=",
+        "lastModified": 1778427648,
+        "narHash": "sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "894a3d23ac0c8aaf561b9874b528b9cb2e839201",
+        "rev": "6f293daa9f9f5832e13b497976335e90509886d7",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.1",
+        "ref": "5.1.11",
         "repo": "brew",
         "type": "github"
       }
@@ -48,7 +48,6 @@
           "llm-agents",
           "flake-parts"
         ],
-        "import-tree": "import-tree",
         "nixpkgs": [
           "llm-agents",
           "nixpkgs"
@@ -63,16 +62,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776182890,
-        "narHash": "sha256-+/VOe8XGq5klpU+I19D+3TcaR7o+Cwbq67KNF7mcFak=",
-        "owner": "Mic92",
+        "lastModified": 1778445566,
+        "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
+        "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "648d293c51e981aec9cb07ba4268bc19e7a8c575",
+        "rev": "2499dedd70744dba1815875b854818a3019e9e4c",
         "type": "github"
       },
       "original": {
-        "owner": "Mic92",
-        "ref": "catalog-support",
+        "owner": "nix-community",
+        "ref": "staging-2.1.0",
         "repo": "bun2nix",
         "type": "github"
       }
@@ -84,11 +83,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775037210,
-        "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
@@ -102,11 +101,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -123,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -195,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776904464,
-        "narHash": "sha256-sBUCj7/4d3Hoevpu3oQp8ccJNA1EDeVmFi1F8O6VJro=",
+        "lastModified": 1779027260,
+        "narHash": "sha256-ZbgWWFQmSyM3HQ31nAZk2hJ7OSeNr9uRFHL8jCifY9M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "667b3c47325441e6a444faaf405bba76ec70338a",
+        "rev": "bcb774cfc3268120cd61808629f9aa7dad3750a2",
         "type": "github"
       },
       "original": {
@@ -228,11 +227,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776910350,
-        "narHash": "sha256-JSnqRGPV2VIHP1zmqgn2hSybSqegvEchYvX5bLc0CZo=",
+        "lastModified": 1779056842,
+        "narHash": "sha256-0WypV0amirXCQEygCCUV0bgczM4qMFZ9W/ojOBTQvaE=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "333331ad54c3b68a61944259cc83d2996a51ece5",
+        "rev": "56eaa1b821712cba5f5cd90f95b471c5e836e28a",
         "type": "github"
       },
       "original": {
@@ -244,31 +243,16 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776910485,
-        "narHash": "sha256-liOlVn5uZB6eA/M8oPdwAOnkXbbNP/BUA0uGNGdgd1c=",
+        "lastModified": 1779053656,
+        "narHash": "sha256-CSBnWQzuZ3UQGdJ0twmg1rGdbgmEI30NMesRg2VFZto=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "0cda532fd96425dde6a3d6bba0296d7814af5190",
+        "rev": "30f66698b7e885e56ff4119371a4cfb49c381f29",
         "type": "github"
       },
       "original": {
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "type": "github"
-      }
-    },
-    "import-tree": {
-      "locked": {
-        "lastModified": 1763762820,
-        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
-        "owner": "vic",
-        "repo": "import-tree",
-        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vic",
-        "repo": "import-tree",
         "type": "github"
       }
     },
@@ -299,11 +283,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1776883427,
-        "narHash": "sha256-prHCm++hniRcoqzvWTEFyAiLKT6m+EUVCRaDLrsuEgM=",
+        "lastModified": 1779053270,
+        "narHash": "sha256-Ec4je/lnXblmekwsINNFjBRU/t0E9joLUkR90HbdcQY=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "6fd26c9cb50d9549f3791b3d35e4f72f97677103",
+        "rev": "f8d389c22727d14c76b973f1c048922d86458245",
         "type": "github"
       },
       "original": {
@@ -317,11 +301,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1774720267,
-        "narHash": "sha256-YYftFe8jyfpQI649yfr0E+dqEXE2jznZNcYvy/lKV1U=",
+        "lastModified": 1778851564,
+        "narHash": "sha256-p8wzcnpB2Iys+QzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE=",
         "owner": "zhaofengli-wip",
         "repo": "nix-homebrew",
-        "rev": "a7760a3a83f7609f742861afb5732210fdc437ed",
+        "rev": "b3a87b4793205cc111f3c61e25e018ffac3b8039",
         "type": "github"
       },
       "original": {
@@ -332,11 +316,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -348,11 +332,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
@@ -363,11 +347,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -379,16 +363,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "lastModified": 1778737229,
+        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,22 @@
 {
   description = "Nix system manager";
 
+  # Personal binary cache, scoped to this flake only. Kept out of the
+  # machine-wide nix-darwin substituters on purpose: as a global substituter
+  # it leaked into every unrelated devenv project, whose cache probe hits this
+  # private cache unauthenticated and warns `HTTP error 401`. Scoping it here
+  # means only `nix run .#switch` (operations on this flake) uses it. The
+  # daemon authenticates via /etc/nix/netrc (see README).
+  nixConfig = {
+    extra-substituters = ["https://grady-saccullo.cachix.org"];
+    extra-trusted-public-keys = [
+      "grady-saccullo.cachix.org-1:eYGgNiaxvbtKg9XDaDw8POg+R92uwljqdlcE32nL9ts="
+    ];
+  };
+
   inputs = {
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     home-manager.inputs.nixpkgs.follows = "nixpkgs-unstable";
     home-manager.url = "github:nix-community/home-manager/master";
 

--- a/modules/applications/default.nix
+++ b/modules/applications/default.nix
@@ -32,6 +32,7 @@
     ./soundsource
     ./spotify
     ./starship
+    ./steam
     ./tailscale
     ./tmux
     ./todoist

--- a/modules/applications/direnv/default.nix
+++ b/modules/applications/direnv/default.nix
@@ -13,5 +13,8 @@ utils.mkAppModule {
         enable = true;
         enableZshIntegration = config.applications.zsh.enable;
         nix-direnv.enable = true;
+        # Suppress the noisy `direnv: export +VAR +VAR ...` env-diff dump on
+        # every shell entry. Keeps the concise `direnv: loading` status line.
+        config.global.hide_env_diff = true;
       };
     })

--- a/modules/applications/steam/default.nix
+++ b/modules/applications/steam/default.nix
@@ -1,0 +1,43 @@
+{
+  utils,
+  config,
+  lib,
+  pkgs,
+  machineType,
+  ...
+}: let
+  isDarwin = machineType == "darwin";
+in
+  utils.mkAppModule {
+    path = "steam";
+    inherit config;
+    extraOptions = {
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.unstable.steam;
+      };
+      path = lib.mkOption {
+        type = lib.types.str;
+        default =
+          if isDarwin
+          then "/Applications/Steam.app"
+          else "${config.applications.steam.package}/Applications/Steam.app";
+      };
+    };
+  } (cfg:
+    utils.mkPlatformConfig {
+      darwin = {
+        homebrew.casks = [
+          {
+            name = "steam";
+            greedy = true;
+          }
+        ];
+      };
+      nixos = utils.mkHomeManagerUser {
+        home.packages = [cfg.package];
+      };
+      linux = utils.mkHomeManagerUser {
+        home.packages = [cfg.package];
+      };
+    })

--- a/modules/applications/wezterm/config.lua
+++ b/modules/applications/wezterm/config.lua
@@ -12,6 +12,24 @@ local resurrect = wezterm.plugin.require("https://github.com/MLFlexer/resurrect.
 
 local tabline = wezterm.plugin.require("https://github.com/michaelbrusegard/tabline.wez")
 
+local wezterm = require("wezterm")
+local config = wezterm.config_builder and wezterm.config_builder() or {}
+
+-- Wezsesh
+local wezsesh_root = "/Users/hackerman/code/grady-saccullo/wezsesh/plugin"
+local wezsesh_binary = "/Users/hackerman/code/grady-saccullo/wezsesh/wezsesh"
+
+package.path = wezsesh_root
+	.. "/?.lua;"
+	.. wezsesh_root
+	.. "/?/init.lua;"
+	.. wezsesh_root
+	.. "/wezsesh/?.lua;"
+	.. wezsesh_root
+	.. "/wezsesh/?/init.lua;"
+	.. package.path
+local wezsesh = dofile(wezsesh_root .. "/init.lua")
+
 local oxocarbon = {
 	background = "#161616",
 	foreground = "#ffffff",
@@ -78,6 +96,7 @@ local config = {
 		timeout_milliseconds = 2000,
 	},
 	keys = {
+		{ key = "L", mods = "CTRL|SHIFT", action = wezterm.action.ShowDebugOverlay },
 		{
 			key = "LeftArrow",
 			mods = "OPT",
@@ -232,6 +251,13 @@ local config = {
 			mods = "LEADER",
 			action = workspace_switcher.switch_workspace(),
 		},
+		-- {
+		-- 	key = "W",
+		-- 	mods = "LEADER|SHIFT",
+		-- 	action = wezterm.action_callback(function(window, pane)
+		-- 		workspace_manager(window, pane)
+		-- 	end),
+		-- },
 		{
 			key = "o",
 			mods = "LEADER",
@@ -250,32 +276,6 @@ local config = {
 				resurrect.state_manager.save_state(resurrect.workspace_state.get_workspace_state())
 			end),
 		},
-		{
-			key = "R",
-			mods = "LEADER|SHIFT",
-			action = wezterm.action_callback(function(win, pane)
-				resurrect.fuzzy_loader.fuzzy_load(win, pane, function(id, label)
-					local type = string.match(id, "^([^/]+)")
-					id = string.match(id, "([^/]+)$")
-					id = string.match(id, "(.+)%..+$")
-					local opts = {
-						relative = true,
-						restore_text = true,
-						on_pane_restore = resurrect.tab_state.default_on_pane_restore,
-					}
-					if type == "workspace" then
-						local state = resurrect.state_manager.load_state(id, "workspace")
-						resurrect.workspace_state.restore_workspace(state, opts)
-					elseif type == "window" then
-						local state = resurrect.state_manager.load_state(id, "window")
-						resurrect.window_state.restore_window(pane:window(), state, opts)
-					elseif type == "tab" then
-						local state = resurrect.state_manager.load_state(id, "tab")
-						resurrect.tab_state.restore_tab(pane:tab(), state, opts)
-					end
-				end)
-			end),
-		},
 	},
 }
 
@@ -291,24 +291,30 @@ smart_splits.apply_to_config(config, {
 	},
 })
 
--- Show explicit tab title if set (via Leader+,), otherwise show parent/current dir.
-local function tab_title_or_cwd(tab)
-	if tab.tab_title and #tab.tab_title > 0 then
-		return tab.tab_title
-	end
-	local pane = tab.active_pane
-	local cwd_uri = pane and pane.current_working_dir
-	if cwd_uri then
-		local path = (cwd_uri.file_path or tostring(cwd_uri)):gsub("/$", "")
-		local parent = path:match("([^/]+)/[^/]+$")
-		local current = path:match("([^/]+)$") or path
-		if parent then
-			return parent .. "/" .. current
-		end
-		return current
-	end
-	return (pane and pane.title) or ""
-end
+wezsesh.apply_to_config(config, {
+	binary = wezsesh_binary,
+	resurrect = resurrect,
+	snapshot_dir = wezterm.home_dir .. "/Library/Application Support/wezterm/resurrect",
+	state_dir = wezterm.home_dir .. "/.local/state/wezsesh",
+	data_dir = wezterm.home_dir .. "/.local/share/wezsesh",
+	runtime_dir = "/tmp/wezsesh",
+	log_level = "debug",
+	-- dir_providers feed the picker with rows that are neither live
+	-- nor saved (the "external" source). Selecting one renames the
+	-- current workspace to the picked name and `cd`s the active pane
+	-- into the supplied path — replaces the smart_workspace_switcher
+	-- + zoxide flow.
+	--
+	-- Each entry is a typed config table. The Go binary executes
+	-- them natively (shell-out for `command`, fs walk for
+	-- `directory`, literal list for `static`). Fields:
+	--   command:   argv (required), limit (default 200), timeout_ms (default 5000)
+	--   directory: path (required), depth (default 2), limit, include_hidden
+	--   static:    paths (required)
+	dir_providers = {
+		{ type = "command", argv = { "zoxide", "query", "-l" }, limit = 200 },
+	},
+})
 
 tabline.setup({
 	options = {
@@ -328,12 +334,12 @@ tabline.setup({
 		tabline_c = { " " },
 		tab_active = {
 			"index",
-			{ tab_title_or_cwd, padding = { left = 1, right = 1 } },
+			{ "tab", padding = { left = 1, right = 1 } },
 			{ "zoomed", padding = 0 },
 		},
 		tab_inactive = {
 			"index",
-			{ tab_title_or_cwd, padding = { left = 1, right = 1 } },
+			{ "tab", padding = { left = 1, right = 1 } },
 		},
 		tabline_x = {},
 		tabline_y = { "datetime" },

--- a/modules/applications/wezterm/default.nix
+++ b/modules/applications/wezterm/default.nix
@@ -37,6 +37,7 @@ in
       programs.wezterm = {
         enable = true;
         package = cfg.package;
+        enableZshIntegration = config.applications.zsh.enable;
         extraConfig = builtins.readFile ./config.lua;
       };
     })

--- a/modules/applications/zsh/default.nix
+++ b/modules/applications/zsh/default.nix
@@ -84,6 +84,8 @@ utils.mkAppModule {
           zle -N rationalise-dot
           bindkey . rationalise-dot
           bindkey -M isearch . self-insert
+
+          WEZSESH_KEEP_PANE=1
         '';
         autosuggestion.enable = true;
         syntaxHighlighting.enable = true;

--- a/modules/shared/nix.nix
+++ b/modules/shared/nix.nix
@@ -7,14 +7,16 @@
     settings = {
       trusted-users = ["root" "${me.user}"];
       netrc-file = "/etc/nix/netrc";
+      # Public caches only. The personal grady-saccullo.cachix.org cache is
+      # scoped to this flake's nixConfig (see flake.nix) instead of being a
+      # machine-wide substituter, so it no longer leaks 401 warnings into
+      # unrelated devenv projects.
       extra-substituters = [
         "https://cache.numtide.com"
-        "https://grady-saccullo.cachix.org"
         "https://nix-community.cachix.org"
       ];
       extra-trusted-public-keys = [
         "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
-        "grady-saccullo.cachix.org-1:eYGgNiaxvbtKg9XDaDw8POg+R92uwljqdlcE32nL9ts="
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       ];
     };


### PR DESCRIPTION
## Summary
- **Fix cachix 401 warnings in unrelated devenv projects**: move the personal `grady-saccullo.cachix.org` substituter out of the machine-wide `nix.settings` and into a flake-scoped `nixConfig` so it only applies to `nix run .#switch` on this flake. Also flip the `/etc/nix/netrc` mode from `0600` → `0644` so both the daemon and user-side flake evaluation can authenticate. README rewritten to explain both decisions.
- **Bump inputs**: nixpkgs/nixpkgs-unstable + home-manager + nix-darwin + flake-parts + homebrew taps, `nixos-25.05` → `nixos-25.11`, Homebrew `5.1.1` → `5.1.11`, and switch `bun2nix` from the `Mic92/catalog-support` fork back to `nix-community/staging-2.1.0` (drops the `import-tree` transitive input).
- **New `steam` app module** wired into `personal-darwin` (homebrew cask on Darwin, nixpkgs package on Linux/NixOS); also re-enable `soundsource` on personal-darwin.
- **Wezterm: integrate wezsesh** (local Go binary + Lua plugin) as the workspace/session manager. Replaces the bespoke `tab_title_or_cwd` helper and the `LEADER|SHIFT R` resurrect fuzzy-loader binding; adds a `CTRL|SHIFT L` debug overlay binding. Tabline now uses the plugin's `tab` component. Enables `enableZshIntegration` in home-manager.
- **Smaller QoL**: `direnv` suppresses the noisy `export +VAR …` env-diff dump (`hide_env_diff = true`); zsh exports `WEZSESH_KEEP_PANE=1`.

## Test plan
- [ ] `nix run .#switch` builds clean on personal-darwin and pulls from the private cache without prompting (netrc present at `0644`).
- [ ] Open an unrelated `devenv`/`nix develop` shell outside this flake — confirm no more `HTTP error 401` warnings from `grady-saccullo.cachix.org` (it should no longer appear as a substituter at all).
- [ ] `steam.enable = true` produces `/Applications/Steam.app` via homebrew cask after switch.
- [ ] Launch wezterm: tabs render via the new tabline `tab` component, `CTRL|SHIFT L` opens the debug overlay, and `wezsesh` picks up the zoxide dir provider.
- [ ] `cd` into a direnv-managed dir — only the concise `direnv: loading` line shows, no `export +…` dump.